### PR TITLE
feat: allow printing with default colors

### DIFF
--- a/rich.c
+++ b/rich.c
@@ -14,8 +14,8 @@ typedef struct {
 } ColorTriplet;
 
 typedef struct {
-    ColorTriplet triplet;
     ColorType type;
+    ColorTriplet triplet;
 } Color;
 
 typedef struct {
@@ -29,20 +29,28 @@ typedef struct {
 } Text;
 
 Color color_from_rgb(int red, int green, int blue) {
-    Color color = {.triplet = {red, green, blue}, .type = TRUECOLOR};
+    Color color = {.type = TRUECOLOR, .triplet = {red, green, blue}};
     return color;
 }
 
 char *color_get_ansi_code(Color color, bool foreground) {
     char *ansi_code = NULL;
-    asprintf(
-        &ansi_code,
-        "%d;2;%d;%d;%d",
-        foreground ? 38 : 48,
-        color.triplet.red,
-        color.triplet.green,
-        color.triplet.blue
-    );
+    switch (color.type) {
+        case DEFAULT:
+            asprintf(&ansi_code, "%d", foreground ? 39 : 49);
+            break;
+        case TRUECOLOR:
+            asprintf(
+                &ansi_code,
+                "%d;2;%d;%d;%d",
+                foreground ? 38 : 48,
+                color.triplet.red,
+                color.triplet.green,
+                color.triplet.blue
+            );
+            break;
+    }
+
     return ansi_code;
 }
 
@@ -69,7 +77,7 @@ void rich_print(Text text) {
 int main() {
     Style style = {
         .color = color_from_rgb(255, 0, 0),
-        .bgcolor = color_from_rgb(255, 255, 0)
+        // .bgcolor = color_from_rgb(255, 255, 0)
     };
     Text text = {"Hello, World!\n", style};
 

--- a/rich.c
+++ b/rich.c
@@ -2,10 +2,20 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+typedef enum {
+    DEFAULT,
+    TRUECOLOR,
+} ColorType;
+
 typedef struct {
     int red;
     int green;
     int blue;
+} ColorTriplet;
+
+typedef struct {
+    ColorTriplet triplet;
+    ColorType type;
 } Color;
 
 typedef struct {
@@ -18,15 +28,20 @@ typedef struct {
     Style style;
 } Text;
 
+Color color_from_rgb(int red, int green, int blue) {
+    Color color = {.triplet = {red, green, blue}, .type = TRUECOLOR};
+    return color;
+}
+
 char *color_get_ansi_code(Color color, bool foreground) {
     char *ansi_code = NULL;
     asprintf(
         &ansi_code,
         "%d;2;%d;%d;%d",
         foreground ? 38 : 48,
-        color.red,
-        color.green,
-        color.blue
+        color.triplet.red,
+        color.triplet.green,
+        color.triplet.blue
     );
     return ansi_code;
 }
@@ -52,7 +67,10 @@ void rich_print(Text text) {
 }
 
 int main() {
-    Style style = {.color = {255, 0, 0}, .bgcolor = {255, 255, 0}};
+    Style style = {
+        .color = color_from_rgb(255, 0, 0),
+        .bgcolor = color_from_rgb(255, 255, 0)
+    };
     Text text = {"Hello, World!\n", style};
 
     rich_print(text);


### PR DESCRIPTION
Allow printing with default colors by changing the `Color` struct and adding a `ColorType` enum.

```c
    Style style = {
        .color = color_from_rgb(255, 0, 0),
        // Note that no background color is provided.
    };
    Text text = {"Hello, World!\n", style};
```